### PR TITLE
build(jest): add @test path alias for test directory

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
   // Maps the '@/' path alias to the 'src' directory for clean imports.
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^\\$/(.*)$': '<rootDir>/test/$1',
   },
 
   // Ignore the E2E test folder to ensure unit and E2E tests are separated.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "db:wait": "wait-on tcp:5432 -t 30000",
     "db:init": "docker-compose exec -T postgres-auth sh -c \"psql -U $POSTGRES_USER -d $POSTGRES_DB -a -f /docker-entrypoint-initdb.d/init.sql\"",
     "start:docker": "docker-compose -f docker-compose.dev.yml up --build -d",
-    "stop:docker": "docker-compose -f docker-compose.dev.yml down",
     "test:e2e:run": "jest --config test/jest-e2e.config.ts --runInBand --forceExit",
     "test:e2e": "npm-run-all db:start db:wait test:e2e:run"
   },

--- a/src/modules/auth/application/services/auth.service.spec.ts
+++ b/src/modules/auth/application/services/auth.service.spec.ts
@@ -6,7 +6,7 @@ import { IHashProvider } from '@/modules/auth/infrastructure/providers/hash/i-ha
 import { JwtService } from '@nestjs/jwt'
 import { ConfigService } from '@nestjs/config'
 import { Sequelize } from 'sequelize-typescript'
-import { userStub } from '../../../../../test/stubs/user.stub'
+import { userStub } from '$/stubs/user.stub'
 import { UnauthorizedException, ForbiddenException, NotFoundException } from '@nestjs/common'
 
 describe('AuthService', () => {

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -13,7 +13,7 @@ import { SequelizeRefreshTokensRepository } from './infrastructure/persistence/s
 import { AuthCleanupService } from './application/services/auth-cleanup.service'
 import { JwtStrategy } from './infrastructure/http/strategies/jwt.strategy'
 import { HashModule } from './hash.module'
-import { UserModule } from '../user/user.module'
+import { UserModule } from '@/modules/user/user.module'
 
 @Module({
   imports: [

--- a/src/modules/auth/infrastructure/persistence/sequelize/repositories/sequelize-refresh-tokens.repository.spec.ts
+++ b/src/modules/auth/infrastructure/persistence/sequelize/repositories/sequelize-refresh-tokens.repository.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { getModelToken } from '@nestjs/sequelize'
 import { SequelizeRefreshTokensRepository } from './sequelize-refresh-tokens.repository'
-import { RefreshTokenModel } from '../models/refresh-token.model'
+import { RefreshTokenModel } from '@/modules/auth/infrastructure/persistence/sequelize/models/refresh-token.model'
 import { Op } from 'sequelize'
 
 // Mock the RefreshTokenModel
@@ -40,6 +40,7 @@ describe('SequelizeRefreshTokensRepository', () => {
         id: '1',
         user_id: '1',
         token_hash: 'hash',
+        client_id: 'client-123', // Added client_id
         expires_at: new Date(),
       }
       mockRefreshTokenModel.create.mockResolvedValue({ toJSON: () => tokenData })

--- a/src/modules/health/application/health.check.use-case.spec.ts
+++ b/src/modules/health/application/health.check.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { HealthIndicator, HealthResult } from '../domain/health.indicator'
+import { HealthIndicator, HealthResult } from '@/modules/health/domain/health.indicator'
 import { HealthCheckUseCase } from './health.check.use-case'
 
 class MockHealthIndicator extends HealthIndicator {

--- a/src/modules/health/application/health.check.use-case.ts
+++ b/src/modules/health/application/health.check.use-case.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common'
-import { HealthIndicator } from '../domain/health.indicator'
+import { HealthIndicator } from '@/modules/health/domain/health.indicator'
 
 export interface OverallHealthStatus {
   status: 'ok' | 'error'

--- a/src/modules/health/infrastructure/database.health.indicator.ts
+++ b/src/modules/health/infrastructure/database.health.indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { Sequelize } from 'sequelize-typescript'
-import { HealthIndicator, HealthResult } from '../domain/health.indicator'
+import { HealthIndicator, HealthResult } from '@/modules/health/domain/health.indicator'
 
 @Injectable()
 export class DatabaseHealthIndicator implements HealthIndicator {

--- a/src/modules/user/application/services/user.service.spec.ts
+++ b/src/modules/user/application/services/user.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { ConflictException, NotFoundException } from '@nestjs/common'
 import { UserService } from './user.service'
-import { userStub } from '../../../../../test/stubs/user.stub'
+import { userStub } from '$/stubs/user.stub'
 import { User } from '@/modules/user/domain/entities/user.entity'
 import {
   IUsersRepository,

--- a/src/modules/user/application/services/user.service.ts
+++ b/src/modules/user/application/services/user.service.ts
@@ -8,7 +8,7 @@ import { IHashProvider, IHashProvider as IHashProviderSymbol } from '@/modules/a
 import { User } from '@/modules/user/domain/entities/user.entity'
 import { Role } from '@/modules/user/domain/enums/role.enum'
 import { UpdateUserProfileDto } from '@/modules/user/infrastructure/http/dto/update-user-profile.dto'
-import { CreateUserDto } from '../../infrastructure/http/dto/create-user.dto'
+import { CreateUserDto } from '@/modules/user/infrastructure/http/dto/create-user.dto'
 
 @Injectable()
 export class UserService {

--- a/src/modules/user/domain/entities/user.entity.ts
+++ b/src/modules/user/domain/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Role } from '../enums/role.enum'
+import { Role } from '@/modules/user/domain/enums/role.enum'
 
 export class User {
   id: string

--- a/src/modules/user/domain/repositories/i-users.repository.ts
+++ b/src/modules/user/domain/repositories/i-users.repository.ts
@@ -1,4 +1,4 @@
-import { User } from '../entities/user.entity'
+import { User } from '@/modules/user/domain/entities/user.entity'
 
 export const IUsersRepository = Symbol('IUsersRepository')
 

--- a/src/modules/user/infrastructure/http/controllers/users.controller.ts
+++ b/src/modules/user/infrastructure/http/controllers/users.controller.ts
@@ -5,11 +5,11 @@ import { AuthGuard } from '@nestjs/passport'
 
 import { UserService } from '@/modules/user/application/services/user.service'
 import { CreateUserDto } from '@/modules/user/infrastructure/http/dto/create-user.dto'
-import { UserProfileResponseDto } from '../dto/user-profile-response.dto'
+import { UserProfileResponseDto } from '@/modules/user/infrastructure/http/dto/user-profile-response.dto'
 import { Roles } from '@/shared/decorators/roles.decorator'
 import { Role } from '@/modules/user/domain/enums/role.enum'
 import { RolesGuard } from '@/shared/guards/roles.guard'
-import { UpdateUserProfileDto } from '../dto/update-user-profile.dto'
+import { UpdateUserProfileDto } from '@/modules/user/infrastructure/http/dto/update-user-profile.dto'
 
 @ApiTags('Users')
 @Controller('users')

--- a/src/modules/user/infrastructure/persistence/sequelize/repositories/sequelize-users.repository.spec.ts
+++ b/src/modules/user/infrastructure/persistence/sequelize/repositories/sequelize-users.repository.spec.ts
@@ -1,12 +1,12 @@
 import { SequelizeUsersRepository } from './sequelize-users.repository'
 import { getModelToken } from '@nestjs/sequelize'
 import { Test, TestingModule } from '@nestjs/testing'
-import { UserModel } from '../models/user.model'
-import { userStub } from '../../../../../../../test/stubs/user.stub'
+import { UserModel } from '@/modules/user/infrastructure/persistence/sequelize/models/user.model'
+import { userStub } from '$/stubs/user.stub'
 import { Op } from 'sequelize'
-import { UserClientModel } from '../models/user-client.model'
+import { UserClientModel } from '@/modules/user/infrastructure/persistence/sequelize/models/user-client.model'
 import { ClientModel } from '@/modules/client/infrastructure/persistence/sequelize/models/client.model'
-import { userClientStub } from '../../../../../../../test/stubs/user_client.stub'
+import { userClientStub } from '$/stubs/user_client.stub'
 
 const userModelInstance = {
   ...userStub(),

--- a/src/modules/user/infrastructure/persistence/sequelize/repositories/sequelize-users.repository.ts
+++ b/src/modules/user/infrastructure/persistence/sequelize/repositories/sequelize-users.repository.ts
@@ -7,7 +7,7 @@ import { User } from '@/modules/user/domain/entities/user.entity'
 import { generateUniqueId } from '@/shared/utils/generate-unique-id'
 import { Op } from 'sequelize'
 import { ClientModel } from '@/modules/client/infrastructure/persistence/sequelize/models/client.model'
-import { UserClientModel } from '../models/user-client.model'
+import { UserClientModel } from '@/modules/user/infrastructure/persistence/sequelize/models/user-client.model'
 
 @Injectable()
 export class SequelizeUsersRepository implements IUsersRepository {

--- a/src/shared/guards/roles.guard.ts
+++ b/src/shared/guards/roles.guard.ts
@@ -1,7 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { Role } from '@/modules/user/domain/enums/role.enum'
-import { ROLES_KEY } from '../decorators/roles.decorator'
+import { ROLES_KEY } from '@/shared/decorators/roles.decorator'
 
 @Injectable()
 export class RolesGuard implements CanActivate {

--- a/test/jest-e2e.config.ts
+++ b/test/jest-e2e.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
   // Maps the '@/' path alias to the 'src' directory, allowing clean imports in tests.
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^\\$/(.*)$': '<rootDir>/test/$1',
   },
 
   // Automatically clear mocks between every test.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"] // Maps any import starting with '@/' to the 'src/' directory.
+      "@/*": ["src/*"], // Maps any import starting with '@/' to the 'src/' directory.
+      "$/*": ["test/*"] // Maps any import starting with '$/' to the 'test/' directory.
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This change introduces the `@test` module alias to the Jest configuration, mapping it to the root `test/` directory.

This allows for cleaner and more consistent import paths for test utilities, factories, and other test-specific modules, similar to how `@/` is used for the `src/` directory.